### PR TITLE
Fix: Add requests to dependencies and workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,10 +27,10 @@ jobs:
           python-version: '3.10' # Specify your Python version
 
       # Optional: Install dependencies if you have a requirements.txt
-      # - name: Install dependencies
-      #   run: |
-      #     python -m pip install --upgrade pip
-      #     if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
       - name: Run adsb_fetcher.py to update flight_log.db
         run: python adsb_fetcher.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+requests


### PR DESCRIPTION
The adsb_fetcher.py script was failing due to a ModuleNotFoundError for the 'requests' module in the GitHub Actions environment.

This commit addresses the issue by:
1. Creating a `requirements.txt` file and adding `requests` to it.
2. Modifying the `.github/workflows/main.yml` to install dependencies from `requirements.txt` before running any scripts.

This ensures that the `requests` module is available when the workflow executes `adsb_fetcher.py`.